### PR TITLE
Use relative URL to cmake-tools submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake/tools"]
 	path = cmake/tools
-	url = https://github.com/rtlabs-com/cmake-tools.git
+	url = ../cmake-tools


### PR DESCRIPTION
Transparently support local mirror for cloning efficiency and possibility
for local changes.