### PR TITLE
Upload clang analysis only if issues were found

### DIFF
--- a/.github/workflows/clang-analysis.yml
+++ b/.github/workflows/clang-analysis.yml
@@ -23,7 +23,18 @@ jobs:
       with:
         submodules: true
 
+    # Run clang analyzer.
+    #
+    # Detect if issues were found and upload SARIF report only in that
+    # case, because reports without entries are not accepted. See
+    # https://github.com/github/codeql-action/issues/390. The analyzer
+    # is run twice in order to get a SARIF report as well as an exit
+    # status when issues are detected, as the scan-build --status-bugs
+    # parameter doesn't work when the output format is SARIF.
+
     - name: Run analyzer
+      id: analyze
+      continue-on-error: true
       run: |
           cmake -E make_directory ${{github.workspace}}/build.clang
           scan-build cmake \
@@ -37,13 +48,21 @@ jobs:
              make \
                -C ${{github.workspace}}/build.clang \
                -j4
+          cmake --build ${{github.workspace}}/build.clang --target clean
+          scan-build \
+             --status-bugs \
+             make \
+               -C ${{github.workspace}}/build.clang \
+               -j4
 
-    - name: Merge results
+    - name: Merge results if any
+      if: steps.analyze.outcome == 'failure'
       uses: microsoft/sarif-actions@v0.1
       with:
         command: 'merge sarif/*/*.sarif'
 
-    - name: Upload results
+    - name: Upload results if any
+      if: steps.analyze.outcome == 'failure'
       uses: github/codeql-action/upload-sarif@v1
       with:
         sarif_file: ${{github.workspace}}/merged.sarif


### PR DESCRIPTION
Detect if issues were found and upload SARIF report only in that case,
because reports without entries are not accepted. See
https://github.com/github/codeql-action/issues/390.

The analyzer is run twice in order to get a SARIF report as well as an
exit status when issues are detected, as the scan-build --status-bugs
parameter doesn't work when the output format is SARIF.