### PR TITLE
fix: add find_package(Threads) to the OsalConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,12 +110,6 @@ install(FILES
   DESTINATION cmake
   )
   
-#install(
-#  EXPORT OsalTargets
-#  FILE OsalConfig.cmake
-#  DESTINATION cmake
-#  )
-
 install(FILES
   include/osal.h
   include/osal_log.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,29 @@ install(
 
 install(
   EXPORT OsalTargets
-  FILE OsalConfig.cmake
+  FILE OsalTargets.cmake
+  DESTINATION cmake
+)
+  
+  
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/OsalConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/OsalConfig.cmake"
+  INSTALL_DESTINATION cmake
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/OsalConfig.cmake
   DESTINATION cmake
   )
+  
+#install(
+#  EXPORT OsalTargets
+#  FILE OsalConfig.cmake
+#  DESTINATION cmake
+#  )
 
 install(FILES
   include/osal.h

--- a/cmake/OsalConfig.cmake.in
+++ b/cmake/OsalConfig.cmake.in
@@ -1,4 +1,8 @@
-find_package(Threads REQUIRED)
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    find_package(Threads REQUIRED)
+endif()
+
 
 @PACKAGE_INIT@
 

--- a/cmake/OsalConfig.cmake.in
+++ b/cmake/OsalConfig.cmake.in
@@ -1,0 +1,5 @@
+find_package(Threads REQUIRED)
+
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/OsalTargets.cmake" )


### PR DESCRIPTION
When importing osal into another project the Threads::Threads dependency was not forwarded.
This PR correctly includes the find_package(Threads) into the OsalConfig.cmake. Thus making it possible to include osal as a system dependency. 
This fixes https://github.com/rtlabs-com/p-net/issues/323
