### PR TITLE
Link against kern for rt-kernel

### DIFF
--- a/cmake/rt-kernel.cmake
+++ b/cmake/rt-kernel.cmake
@@ -26,6 +26,10 @@ target_compile_options(osal
   -Wno-unused-parameter
   )
 
+target_link_libraries(osal
+  kern
+  )
+
 target_include_directories(osal PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/rt-kernel>
   )


### PR DESCRIPTION
Osal must be set to link against rt-kernel to inherit proper include directory for rt-kernel.