### PR TITLE
Add tick api to osal

### DIFF
--- a/include/osal.h
+++ b/include/osal.h
@@ -76,11 +76,19 @@ typedef void os_mbox_t;
 typedef void os_timer_t;
 #endif
 
+#ifndef OS_TICK
+typedef void os_tick_t;
+#endif
+
 void * os_malloc (size_t size);
 void os_free (void * ptr);
 
 void os_usleep (uint32_t us);
 uint32_t os_get_current_time_us (void);
+
+os_tick_t os_tick_current (void);
+os_tick_t os_tick_from_us (uint32_t us);
+void      os_tick_sleep (os_tick_t tick);
 
 os_thread_t * os_thread_create (
    const char * name,

--- a/src/freertos/osal.c
+++ b/src/freertos/osal.c
@@ -86,6 +86,21 @@ uint32_t os_get_current_time_us (void)
    return 1000 * (xTaskGetTickCount() / portTICK_PERIOD_MS);
 }
 
+os_tick_t os_tick_current (void)
+{
+   return xTaskGetTickCount();
+}
+
+os_tick_t os_tick_from_us (uint32_t us)
+{
+   return us / (1000u * portTICK_PERIOD_MS);
+}
+
+void os_tick_sleep (os_tick_t tick)
+{
+   vTaskDelay (tick);
+}
+
 os_sem_t * os_sem_create (size_t count)
 {
    SemaphoreHandle_t handle = xSemaphoreCreateCounting (UINT32_MAX, count);

--- a/src/freertos/sys/osal_sys.h
+++ b/src/freertos/sys/osal_sys.h
@@ -33,6 +33,7 @@ extern "C" {
 #define OS_EVENT
 #define OS_MBOX
 #define OS_TIMER
+#define OS_TICK
 
 typedef SemaphoreHandle_t os_mutex_t;
 typedef TaskHandle_t os_thread_t;
@@ -47,6 +48,8 @@ typedef struct os_timer
    void * arg;
    uint32_t us;
 } os_timer_t;
+
+typedef TickType_t os_tick_t;
 
 #ifdef __cplusplus
 }

--- a/src/linux/osal.c
+++ b/src/linux/osal.c
@@ -234,6 +234,36 @@ uint32_t os_get_current_time_us (void)
    return ts.tv_sec * 1000 * 1000 + ts.tv_nsec / 1000;
 }
 
+os_tick_t os_tick_current (void)
+{
+   struct timespec ts;
+   os_tick_t       tick;
+
+   clock_gettime (CLOCK_MONOTONIC, &ts);
+   tick = ts.tv_sec;
+   tick *= NSECS_PER_SEC;
+   tick += ts.tv_nsec;
+   return tick;
+}
+
+os_tick_t os_tick_from_us (uint32_t us)
+{
+   return (os_tick_t)us * 1000;
+}
+
+void os_tick_sleep (os_tick_t tick)
+{
+   struct timespec ts;
+   struct timespec remain;
+
+   ts.tv_sec  = tick / NSECS_PER_SEC;
+   ts.tv_nsec = tick % NSECS_PER_SEC;
+   while (clock_nanosleep (CLOCK_MONOTONIC, 0, &ts, &remain) != 0)
+   {
+      ts = remain;
+   }
+}
+
 os_event_t * os_event_create (void)
 {
    os_event_t * event;

--- a/src/linux/sys/osal_sys.h
+++ b/src/linux/sys/osal_sys.h
@@ -29,6 +29,7 @@ extern "C" {
 #define OS_EVENT
 #define OS_MBOX
 #define OS_TIMER
+#define OS_TICK
 
 typedef pthread_t os_thread_t;
 typedef pthread_mutex_t os_mutex_t;
@@ -69,6 +70,8 @@ typedef struct os_timer
    uint32_t us;
    bool oneshot;
 } os_timer_t;
+
+typedef uint64_t os_tick_t;
 
 #ifdef __cplusplus
 }

--- a/src/rt-kernel/osal.c
+++ b/src/rt-kernel/osal.c
@@ -65,6 +65,21 @@ uint32_t os_get_current_time_us (void)
    return 1000 * tick_to_ms (tick_get());
 }
 
+os_tick_t os_tick_current (void)
+{
+   return tick_get();
+}
+
+os_tick_t os_tick_from_us (uint32_t us)
+{
+   return tick_from_ms (us / 1000);
+}
+
+void os_tick_sleep (os_tick_t tick)
+{
+   task_delay (tick);
+}
+
 os_sem_t * os_sem_create (size_t count)
 {
    return sem_create (count);

--- a/src/rt-kernel/sys/osal_sys.h
+++ b/src/rt-kernel/sys/osal_sys.h
@@ -28,6 +28,7 @@ extern "C" {
 #define OS_EVENT
 #define OS_MBOX
 #define OS_TIMER
+#define OS_TICK
 
 typedef task_t os_thread_t;
 typedef mtx_t os_mutex_t;
@@ -35,6 +36,7 @@ typedef sem_t os_sem_t;
 typedef flags_t os_event_t;
 typedef mbox_t os_mbox_t;
 typedef tmr_t os_timer_t;
+typedef tick_t os_tick_t;
 
 #ifdef __cplusplus
 }

--- a/src/windows/sys/osal_sys.h
+++ b/src/windows/sys/osal_sys.h
@@ -30,6 +30,7 @@ extern "C" {
 #define OS_EVENT
 #define OS_MBOX
 #define OS_TIMER
+#define OS_TICK
 
 typedef HANDLE os_thread_t;
 typedef CRITICAL_SECTION os_mutex_t;
@@ -67,6 +68,8 @@ typedef struct os_timer
    uint32_t us;
    bool oneshot;
 } os_timer_t;
+
+typedef uint64_t os_tick_t;
 
 #ifdef __cplusplus
 }

--- a/test/test_osal.cpp
+++ b/test/test_osal.cpp
@@ -209,3 +209,18 @@ TEST_F (Osal, CurrentTime)
 
    EXPECT_NEAR (100 * 1000, t1 - t0, 1000);
 }
+
+
+TEST_F (Osal, Tick)
+{
+   os_tick_t t0, t1, sleep;
+
+   sleep = os_tick_from_us (100 * 1000);
+   t0 = os_tick_current();
+   os_tick_sleep (sleep);
+   t1 = os_tick_current();
+
+   EXPECT_NEAR ((double)sleep,
+                (double)(t1 - t0),
+                (double)os_tick_from_us (1000));
+}


### PR DESCRIPTION
# Tests
- [x] Tested on linux
- [x] Tested on windows
- [x] Tested on rt-kernel
- [ ] Tested on freertos

# Todo
- [ ] Mark old time function as deprecated?
- [ ] Add api to get tick frequency?

Related to https://github.com/rtlabs-com/osal/pull/18