### PR TITLE
Switch to waitable timers for sleep

### DIFF
--- a/src/windows/sys/osal_sys.h
+++ b/src/windows/sys/osal_sys.h
@@ -68,11 +68,12 @@ typedef struct os_mbox
 
 typedef struct os_timer
 {
-   UINT timerID;
+   HANDLE timer;
    void (*fn) (struct os_timer *, void * arg);
    void * arg;
-   uint32_t us;
+   LARGE_INTEGER time;
    bool oneshot;
+   bool run;
 } os_timer_t;
 
 typedef uint64_t os_tick_t;


### PR DESCRIPTION
This improves accuracy compared to sleep.

This make use of high resolution timers on modern
windows machines to ensure timers as well as sleeps
are close to 1 ms accurate, without raising the
global tick interval.

In theory it should allow more than 1ms accuracy
however, it seem to generally be limited to around
0.6 ms in testing.

Note. Requires windows 10.