### PR TITLE
Ensure CC_ASSERT calls do not have side effects

### DIFF
--- a/src/freertos/osal.c
+++ b/src/freertos/osal.c
@@ -234,20 +234,26 @@ void os_timer_set (os_timer_t * timer, uint32_t us)
 void os_timer_start (os_timer_t * timer)
 {
    /* Start timer by updating the period */
-   CC_ASSERT (
-      xTimerChangePeriod (
+   BaseType_t status = xTimerChangePeriod (
          timer->handle,
          (timer->us / portTICK_PERIOD_MS) / 1000,
-         portMAX_DELAY) == pdPASS);
+         portMAX_DELAY);
+
+   CC_UNUSED (status);
+   CC_ASSERT (status == pdPASS);
 }
 
 void os_timer_stop (os_timer_t * timer)
 {
-   CC_ASSERT (xTimerStop (timer->handle, portMAX_DELAY) == pdPASS);
+   BaseType_t status = xTimerStop (timer->handle, portMAX_DELAY);
+   CC_UNUSED (status);
+   CC_ASSERT (status == pdPASS);
 }
 
 void os_timer_destroy (os_timer_t * timer)
 {
-   CC_ASSERT (xTimerDelete (timer->handle, portMAX_DELAY) == pdPASS);
+   BaseType_t status = xTimerDelete (timer->handle, portMAX_DELAY);
+   CC_UNUSED (status);
+   CC_ASSERT (status == pdPASS);
    free (timer);
 }

--- a/src/freertos/sys/osal_cc.h
+++ b/src/freertos/sys/osal_cc.h
@@ -82,6 +82,7 @@ extern "C"
 
 #define CC_ASSERT(exp) assert (exp)
 #define CC_STATIC_ASSERT(exp) _Static_assert (exp, "")
+#define CC_UNUSED(var) (void)(var)
 
 #ifdef __cplusplus
 }

--- a/src/linux/sys/osal_cc.h
+++ b/src/linux/sys/osal_cc.h
@@ -91,6 +91,8 @@ static inline void cc_assert (int exp) CLANG_ANALYZER_NORETURN
 #define CC_STATIC_ASSERT(exp) _Static_assert(exp, "")
 #endif
 
+#define CC_UNUSED(var) (void)(var)
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rt-kernel/sys/osal_cc.h
+++ b/src/rt-kernel/sys/osal_cc.h
@@ -81,6 +81,7 @@ extern "C" {
 
 #define CC_ASSERT(exp)        ASSERT (exp)
 #define CC_STATIC_ASSERT(exp) _Static_assert(exp, "")
+#define CC_UNUSED(var) (void)(var)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Since builds may be compiled without asserts, it may be the case that expressions that are to be asserted are never evaluated; this would lead to incorrect behaviour if they contain side effects.