### PR TITLE
Fixes for FreeRTOS task creation

### DIFF
--- a/src/freertos/osal.c
+++ b/src/freertos/osal.c
@@ -38,20 +38,18 @@ os_thread_t * os_thread_create (
    void * arg)
 {
    TaskHandle_t xHandle = NULL;
+   BaseType_t status;
 
    /* stacksize in freertos is not in bytes but in stack depth, it should be
     * divided by the stack width */
    configSTACK_DEPTH_TYPE stackdepth =
       stacksize / sizeof (StackType_t);
 
-   if (xTaskCreate (entry, name, stackdepth, arg, priority, &xHandle) == pdPASS)
-   {
-      return (os_thread_t *)xHandle;
-   }
-   else
-   {
-      return NULL;
-   }
+   status = xTaskCreate (entry, name, stackdepth, arg, priority, &xHandle);
+   CC_UNUSED (status);
+   CC_ASSERT (status == pdPASS);
+   CC_ASSERT (xHandle != NULL);
+   return (os_thread_t *)xHandle;
 }
 
 os_mutex_t * os_mutex_create (void)

--- a/src/freertos/osal.c
+++ b/src/freertos/osal.c
@@ -42,7 +42,7 @@ os_thread_t * os_thread_create (
    /* stacksize in freertos is not in bytes but in stack depth, it should be
     * divided by the stack width */
    configSTACK_DEPTH_TYPE stackdepth =
-      stacksize / sizeof (configSTACK_DEPTH_TYPE);
+      stacksize / sizeof (StackType_t);
 
    if (xTaskCreate (entry, name, stackdepth, arg, priority, &xHandle) == pdPASS)
    {


### PR DESCRIPTION
The port for FreeRTOS could allocate task stacks twice as large as expected. Furthermore, if out-of-memory when attempting to create a task, the error would go unreported. This would not necessarily lead to a crash, as the returned task handle is often not used.