### PR TITLE
Add support for os exit logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,9 @@ configure_file (
 
 # Add platform-dependent targets early, so they can be configured by
 # platform
-add_library(osal "")
+add_library(osal
+  "src/osal_utils.c"
+)
 
 # Suppress certain warnings when building with MSVC
 if (WINDOWS_MONO)
@@ -120,6 +122,7 @@ install(FILES
 install(FILES
   include/osal.h
   include/osal_log.h
+  include/osal_utils.h
   DESTINATION include
   )
 

--- a/cmake/Windows.cmake
+++ b/cmake/Windows.cmake
@@ -25,6 +25,7 @@ target_compile_options(osal
     /WX
     /wd4100
     /wd4152
+    /wd4127 # conditional expression is constant
   >
 
   $<$<C_COMPILER_ID:GCC>:

--- a/include/osal.h
+++ b/include/osal.h
@@ -80,6 +80,10 @@ typedef void os_timer_t;
 typedef void os_tick_t;
 #endif
 
+#ifndef OS_EXIT
+typedef int os_exit_t;
+#endif
+
 void * os_malloc (size_t size);
 void os_free (void * ptr);
 
@@ -131,6 +135,8 @@ void os_timer_set (os_timer_t * timer, uint32_t us);
 void os_timer_start (os_timer_t * timer);
 void os_timer_stop (os_timer_t * timer);
 void os_timer_destroy (os_timer_t * timer);
+
+void os_exit (os_exit_t code);
 
 #ifdef __cplusplus
 }

--- a/include/osal_utils.h
+++ b/include/osal_utils.h
@@ -1,0 +1,31 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2025 rt-labs AB, Sweden.
+ *
+ * This software is licensed under the terms of the BSD 3-clause
+ * license. See the file LICENSE distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#ifndef OSAL_UTILS_H
+#define OSAL_UTILS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "osal.h"
+
+void os_exit_later (os_exit_t code, const char * reason, uint32_t us);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OSAL_UTILS_H */

--- a/src/freertos/osal.c
+++ b/src/freertos/osal.c
@@ -255,3 +255,8 @@ void os_timer_destroy (os_timer_t * timer)
    CC_ASSERT (status == pdPASS);
    free (timer);
 }
+
+void os_exit (os_exit_t code)
+{
+   exit (code);
+}

--- a/src/linux/osal.c
+++ b/src/linux/osal.c
@@ -575,3 +575,8 @@ void os_timer_destroy (os_timer_t * timer)
    timer_delete (timer->timerid);
    free (timer);
 }
+
+void os_exit (os_exit_t code)
+{
+   exit (code);
+}

--- a/src/osal_utils.c
+++ b/src/osal_utils.c
@@ -1,0 +1,61 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2025 rt-labs AB, Sweden.
+ *
+ * This software is licensed under the terms of the BSD 3-clause
+ * license. See the file LICENSE distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include <string.h>
+#include <inttypes.h>
+#include "osal_utils.h"
+#include "osal_log.h"
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL LOG_LEVEL_INFO
+#endif
+
+#define MICROSECONDS_PER_SECONDS 10000000u
+
+typedef struct os_exit_later_ctx
+{
+    const char * reason;
+    os_exit_t    code;
+} os_exit_later_ctx_t;
+
+static void os_exit_later_callback (os_timer_t *timer, void * arg)
+{
+    os_exit_later_ctx_t * ctx = arg;
+    LOG_INFO (LOG_STATE_ON,
+              "Exiting system due to: %s\n",
+              ctx->reason);
+    os_exit (ctx->code);
+}
+
+void os_exit_later (os_exit_t code, const char * reason, uint32_t us)
+{
+    os_exit_later_ctx_t * ctx;
+    os_timer_t * tmr;
+    LOG_INFO (LOG_STATE_ON,
+              "System will exit in %"PRIu32" seconds due to: %s\n",
+              us / MICROSECONDS_PER_SECONDS, reason);
+
+    ctx = os_malloc (sizeof (os_exit_later_ctx_t));
+    CC_ASSERT (ctx != NULL);
+
+    memset (ctx, 0, sizeof (os_exit_later_ctx_t));
+    ctx->code = code;
+    ctx->reason = reason;
+
+    tmr = os_timer_create (us, os_exit_later_callback, ctx, true);
+    CC_ASSERT (tmr != NULL);
+
+    os_timer_start (tmr);
+}

--- a/src/rt-kernel/osal.c
+++ b/src/rt-kernel/osal.c
@@ -222,3 +222,8 @@ void os_timer_destroy (os_timer_t * timer)
 {
    tmr_destroy (timer);
 }
+
+void os_exit (os_exit_t code)
+{
+   exit (code);
+}

--- a/src/windows/osal.c
+++ b/src/windows/osal.c
@@ -367,3 +367,8 @@ void os_timer_destroy (os_timer_t * timer)
 {
    free (timer);
 }
+
+void os_exit (os_exit_t code)
+{
+   exit (code);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(osal_test PRIVATE
 
   # Unit tests
   test_osal.cpp
+  test_osal_utils.cpp
 
   # Testrunner
   osal_test.cpp

--- a/test/test_osal_utils.cpp
+++ b/test/test_osal_utils.cpp
@@ -1,0 +1,40 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2017 rt-labs AB, Sweden.
+ *
+ * This software is licensed under the terms of the BSD 3-clause
+ * license. See the file LICENSE distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include "osal.h"
+#include "osal_utils.h"
+#include <gtest/gtest.h>
+
+
+class OsalUtilsDeathTest : public ::testing::Test
+{
+ protected:
+   virtual void SetUp()
+   {
+   }
+};
+
+TEST_F (OsalUtilsDeathTest, ExitLater)
+{
+   const uint32_t delay_in_us = 1000 * 1000; /* 1.0 seconds */
+   const uint32_t error_in_us =  100 * 1000; /* 0.1 seconds */
+   ASSERT_DEATH_IF_SUPPORTED (
+      {
+         os_exit_later (1, "ExitLater", delay_in_us);
+         os_usleep (delay_in_us + error_in_us);
+      },
+      ""
+   );
+}


### PR DESCRIPTION
- Add support for os_exit() to allow a portable wait to indicate that system should shut down
- Add support for a delayed exit routine to indicate shutdown of system after a set delay