### PR TITLE
Backports from uphy development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,14 @@ configure_file (
 # platform
 add_library(osal "")
 
+# Suppress certain warnings when building with MSVC
+if (WINDOWS_MONO)
+target_compile_options (osal
+  PRIVATE
+  /wd4820 # padding added
+  )
+endif()
+
 # Use position independent code if platform supports shared libraries
 get_property(SUPPORTS_SHARED GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
 if (SUPPORTS_SHARED)

--- a/include/osal_log.h
+++ b/include/osal_log.h
@@ -69,7 +69,10 @@ extern "C" {
 #define LOG_ERROR_ENABLED(type)   LOG_ENABLED (LOG_LEVEL_ERROR | type)
 #define LOG_FATAL_ENABLED(type)   LOG_ENABLED (LOG_LEVEL_FATAL | type)
 
-void os_log (uint8_t type, const char * fmt, ...) CC_FORMAT (2, 3);
+
+typedef void (*os_log_t) (uint8_t type, const char * fmt, ...) CC_FORMAT (2, 3);
+
+extern os_log_t os_log;
 
 #ifdef __cplusplus
 }

--- a/src/freertos/sys/osal_cc.h
+++ b/src/freertos/sys/osal_cc.h
@@ -26,6 +26,7 @@ extern "C"
 #define CC_PACKED_BEGIN
 #define CC_PACKED_END
 #define CC_PACKED             __attribute__((packed))
+#define CC_ALIGNED(n)         __attribute__((aligned (n)))
 
 #define CC_FORMAT(str,arg)    __attribute__((format (printf, str, arg)))
 

--- a/src/linux/osal.c
+++ b/src/linux/osal.c
@@ -545,10 +545,12 @@ void os_timer_set (os_timer_t * timer, uint32_t us)
 void os_timer_start (os_timer_t * timer)
 {
    struct itimerspec its;
+   uint32_t sec = timer->us / (1000 * 1000);
+   uint32_t us = timer->us - sec * 1000 * 1000;
 
    /* Start timer */
-   its.it_value.tv_sec     = 0;
-   its.it_value.tv_nsec    = 1000 * timer->us;
+   its.it_value.tv_sec     = sec;
+   its.it_value.tv_nsec    = 1000 * us;
    its.it_interval.tv_sec  = (timer->oneshot) ? 0 : its.it_value.tv_sec;
    its.it_interval.tv_nsec = (timer->oneshot) ? 0 : its.it_value.tv_nsec;
    timer_settime (timer->timerid, 0, &its, NULL);

--- a/src/linux/osal_log.c
+++ b/src/linux/osal_log.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <time.h>
 
-void os_log (uint8_t type, const char * fmt, ...)
+static void os_log_impl (uint8_t type, const char * fmt, ...)
 {
    va_list list;
    time_t rawtime;
@@ -56,3 +56,5 @@ void os_log (uint8_t type, const char * fmt, ...)
    va_end (list);
    fflush (stdout);
 }
+
+os_log_t os_log = os_log_impl;

--- a/src/linux/sys/osal_cc.h
+++ b/src/linux/sys/osal_cc.h
@@ -42,6 +42,7 @@ static inline void cc_assert (int exp) CLANG_ANALYZER_NORETURN
 #define CC_PACKED_BEGIN
 #define CC_PACKED_END
 #define CC_PACKED __attribute__ ((packed))
+#define CC_ALIGNED(n) __attribute__((aligned (n)))
 
 #define CC_FORMAT(str, arg) __attribute__ ((format (printf, str, arg)))
 

--- a/src/rt-kernel/osal_log.c
+++ b/src/rt-kernel/osal_log.c
@@ -20,7 +20,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-void os_log (uint8_t type, const char * fmt, ...)
+void os_log_impl (uint8_t type, const char * fmt, ...)
 {
    va_list list;
 
@@ -49,3 +49,5 @@ void os_log (uint8_t type, const char * fmt, ...)
    vprintf (fmt, list);
    va_end (list);
 }
+
+os_log_t os_log = os_log_impl;

--- a/src/rt-kernel/sys/osal_cc.h
+++ b/src/rt-kernel/sys/osal_cc.h
@@ -26,6 +26,7 @@ extern "C" {
 #define CC_PACKED_BEGIN
 #define CC_PACKED_END
 #define CC_PACKED __attribute__ ((packed))
+#define CC_ALIGNED(n) __attribute__((aligned (n)))
 
 #define CC_FORMAT(str, arg) __attribute__ ((format (printf, str, arg)))
 

--- a/src/windows/osal_log.c
+++ b/src/windows/osal_log.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void os_log (uint8_t type, const char * fmt, ...)
+static void os_log_impl (uint8_t type, const char * fmt, ...)
 {
    va_list list;
 
@@ -49,3 +49,5 @@ void os_log (uint8_t type, const char * fmt, ...)
    va_end (list);
    fflush (stdout);
 }
+
+os_log_t os_log = os_log_impl;

--- a/src/windows/sys/osal_sys.h
+++ b/src/windows/sys/osal_sys.h
@@ -20,7 +20,13 @@
 extern "C" {
 #endif
 
+#define WIN32_LEAN_AND_MEAN /* Do not include <winsock.h> */
 #include <windows.h>
+
+/* Libraries excluded by WIN32_LEAN_AND_MEAN */
+#include <malloc.h>
+#include <timeapi.h>
+#include <mmsystem.h>
 
 #define OS_WAIT_FOREVER INFINITE
 


### PR DESCRIPTION
- Support CCA_ALIGNED on freertos
- Use lean windows headers by default
- Avoid some warnings generated by windows compilers
- Allow changing log callbacks at run time to redirect logging to other systems
- Support log timers on linux